### PR TITLE
Fix phoenix link on the root template

### DIFF
--- a/lib/calendlex_web/templates/layout/root.html.heex
+++ b/lib/calendlex_web/templates/layout/root.html.heex
@@ -15,7 +15,7 @@
     <div class="flex flex-col h-screen">
       <%= @inner_content %>
       <footer class="p-4 mt-auto text-sm text-center text-gray-400 leading-6">
-        <p>Crafted with ❤ and <a class="font-bold text-blue-500" href="https://elm-lang.org/" target="_blank" class="cool">Phoenix</a> by <a class="font-bold text-blue-500" href="https://github.com/bigardone" target="_blank" class="cool">bigardone</a>.</p>
+        <p>Crafted with ❤ and <a class="font-bold text-blue-500" href="https://www.phoenixframework.org/" target="_blank" class="cool">Phoenix</a> by <a class="font-bold text-blue-500" href="https://github.com/bigardone" target="_blank" class="cool">bigardone</a>.</p>
         <p><a class="font-bold text-blue-500" href="https://github.com/bigardone/calendlex" target="_blank">Source code</a> available on GitHub.</p>
       </footer>
     </div>


### PR DESCRIPTION
Fixing the phoenix link, that was redirecting to the [Elm page](https://elm-lang.org/)